### PR TITLE
Expire stale saved Sessions after 60 minutes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,6 +50,15 @@ makes no decision of its own in doing so.
 
 Only running and paused Sessions are saved. A restored Session comes back paused and waits
 behind the resume prompt — a ringing alarm restored on load would beep at a page you just opened.
+It comes back with the time genuinely left, not the time it was saved with.
+
+**Resume Window** — how long past its Deadline a saved Session is still worth offering back:
+one hour (`RESUME_WINDOW_MS`). Every saved payload carries a Deadline, a paused one included —
+there it is the instant the Session would end had it kept running from the save — which is what
+makes a save's age knowable. Past the window the payload is dropped and the storage cleared, and
+the viewer lands on the preset screen. There is no version field and no migration: a payload the
+module does not recognise — junk, or one written before Sessions carried a Deadline — degrades
+the same way, to a fresh start.
 
 **Ambiance** — how the star field looks and behaves in a given mode. **Night** during focus,
 **Dawn** during a break. Owned by the **Ambiance module** (`src/lib/flowstate/ambiance.ts`) —

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,11 +52,13 @@ Only running and paused Sessions are saved. A restored Session comes back paused
 behind the resume prompt — a ringing alarm restored on load would beep at a page you just opened.
 It comes back with the time genuinely left, not the time it was saved with.
 
-**Resume Window** — how long past its Deadline a saved Session is still worth offering back:
-one hour (`RESUME_WINDOW_MS`). Every saved payload carries a Deadline, a paused one included —
-there it is the instant the Session would end had it kept running from the save — which is what
-makes a save's age knowable. Past the window the payload is dropped and the storage cleared, and
-the viewer lands on the preset screen. There is no version field and no migration: a payload the
+**Resume Window** — how long after a Session was last live it is still worth offering back:
+one hour (`RESUME_WINDOW_MS`). Last live means its Deadline while running, and the instant it was
+saved while paused — a paused Session counts down no further, so what makes it stale is how long
+ago it was left. Every saved payload carries a Deadline, a paused one included, where it is the
+instant the Session would end had it kept running from the save; both instants are read off it.
+Past the window the payload is dropped and the storage cleared, and the viewer lands on the
+preset screen. There is no version field and no migration: a payload the
 module does not recognise — junk, or one written before Sessions carried a Deadline — degrades
 the same way, to a fresh start.
 

--- a/src/lib/timer/session.ts
+++ b/src/lib/timer/session.ts
@@ -69,12 +69,19 @@ export interface Outcome {
   effects: Effect[];
 }
 
-/** What a running or paused Session is written to storage as. */
+/**
+ * What a running or paused Session is written to storage as.
+ *
+ * Every saved payload carries a Deadline, including a paused one — for a paused
+ * Session it is the instant it would end had it kept running from the save.
+ * That is what makes a saved Session's age knowable, and so what makes it
+ * expirable. A payload without one is not a payload this version wrote.
+ */
 export interface SavedSession {
   status: 'running' | 'paused';
   mode: Mode;
   totalSeconds: number;
-  endsAt: number | null;
+  endsAt: number;
   remainingSeconds: number;
   lastFocusSeconds: number;
   breakSeconds: number;
@@ -84,6 +91,13 @@ export const DEFAULT_FOCUS_MINUTES = 90;
 export const DEFAULT_BREAK_MINUTES = 30;
 export const MIN_MINUTES = 1;
 export const MAX_MINUTES = 300;
+
+/**
+ * How long past its Deadline a saved Session is still worth offering back.
+ * Walk away from a Session for longer than this and it is gone: the preset
+ * screen is a truer answer than a prompt about something long dead.
+ */
+export const RESUME_WINDOW_MS = 60 * 60 * 1000;
 
 export const FOCUS_PHRASES: readonly string[] = [
   'Go take a nap, you earned it.',
@@ -239,7 +253,10 @@ export function reduce(session: Session, event: Event): Outcome {
       return begin(session, 'focus', session.lastFocusSeconds, event.now);
 
     case 'restore': {
-      const saved = parseSaved(event.payload);
+      // Anything this version does not recognise — junk, a payload from before
+      // Sessions carried a Deadline, or one gone stale — is dropped, and the
+      // storage it came from is cleared rather than left to be re-read.
+      const saved = parseSaved(event.payload, event.now);
       if (!saved) return { session: initialSession(), effects: ['clearSaved'] };
 
       // A restored Session waits for the viewer to say "resume" — it does not
@@ -250,8 +267,11 @@ export function reduce(session: Session, event: Event): Outcome {
           mode: saved.mode,
           totalSeconds: saved.totalSeconds,
           endsAt: null,
+          // A Session that was running kept running while the page was gone,
+          // so the time it comes back with is the time genuinely left. A paused
+          // one was not counting, and comes back with what it was paused at.
           remainingSeconds:
-            saved.status === 'running' && saved.endsAt !== null
+            saved.status === 'running'
               ? secondsUntil(saved.endsAt, event.now)
               : Math.max(0, Math.floor(saved.remainingSeconds)),
           lastFocusSeconds: saved.lastFocusSeconds,
@@ -274,14 +294,14 @@ export function choosePhrase(mode: Mode, draw: number): string {
 
 // === Saved payload ===
 
-/** What to persist, or null when this Session must not be restored. */
-export function toSaved(session: Session): SavedSession | null {
+/** What to persist at `now`, or null when this Session must not be restored. */
+export function toSaved(session: Session, now: number): SavedSession | null {
   if (session.status !== 'running' && session.status !== 'paused') return null;
   return {
     status: session.status,
     mode: session.mode,
     totalSeconds: session.totalSeconds,
-    endsAt: session.endsAt,
+    endsAt: session.endsAt ?? now + session.remainingSeconds * 1000,
     remainingSeconds: session.remainingSeconds,
     lastFocusSeconds: session.lastFocusSeconds,
     breakSeconds: session.breakSeconds,
@@ -292,7 +312,7 @@ function positiveNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function parseSaved(payload: unknown): SavedSession | null {
+function parseSaved(payload: unknown, now: number): SavedSession | null {
   if (typeof payload !== 'object' || payload === null) return null;
   const raw = payload as Record<string, unknown>;
 
@@ -304,17 +324,18 @@ function parseSaved(payload: unknown): SavedSession | null {
     return null;
   }
 
-  const endsAt =
-    typeof raw.endsAt === 'number' && Number.isFinite(raw.endsAt) ? raw.endsAt : null;
+  // No Deadline, no payload: this is either junk or something written before
+  // Sessions carried one, and either way there is no telling how old it is.
+  const endsAt = raw.endsAt;
+  if (typeof endsAt !== 'number' || !Number.isFinite(endsAt)) return null;
+  if (now - endsAt > RESUME_WINDOW_MS) return null;
+
   const remainingSeconds =
     typeof raw.remainingSeconds === 'number' && Number.isFinite(raw.remainingSeconds)
       ? raw.remainingSeconds
       : null;
 
-  // Payloads written before Sessions had a Deadline carry only a remaining
-  // count; they restore as paused, which is how every payload is restored.
   const status = raw.status === 'running' ? 'running' : 'paused';
-  if (status === 'running' && endsAt === null) return null;
   if (status === 'paused' && remainingSeconds === null) return null;
 
   return {

--- a/src/lib/timer/session.ts
+++ b/src/lib/timer/session.ts
@@ -256,8 +256,10 @@ export function reduce(session: Session, event: Event): Outcome {
       // Anything this version does not recognise — junk, a payload from before
       // Sessions carried a Deadline, or one gone stale — is dropped, and the
       // storage it came from is cleared rather than left to be re-read.
-      const saved = parseSaved(event.payload, event.now);
-      if (!saved) return { session: initialSession(), effects: ['clearSaved'] };
+      const saved = parseSaved(event.payload);
+      if (!saved || !withinResumeWindow(saved, event.now)) {
+        return { session: initialSession(), effects: ['clearSaved'] };
+      }
 
       // A restored Session waits for the viewer to say "resume" — it does not
       // resume itself, so it comes back paused however it was saved.
@@ -312,7 +314,23 @@ function positiveNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-function parseSaved(payload: unknown, now: number): SavedSession | null {
+/**
+ * The instant a saved Session stopped being live: its Deadline while running,
+ * and the instant it was written while paused — a paused Session counts down no
+ * further, so what makes it stale is how long ago it was left, not when it
+ * would have ended. Both are read off the Deadline every payload carries.
+ */
+function lastLiveAt(saved: SavedSession): number {
+  if (saved.status === 'running') return saved.endsAt;
+  return saved.endsAt - saved.remainingSeconds * 1000;
+}
+
+/** Whether a saved Session is recent enough to still be worth offering back. */
+function withinResumeWindow(saved: SavedSession, now: number): boolean {
+  return now - lastLiveAt(saved) <= RESUME_WINDOW_MS;
+}
+
+function parseSaved(payload: unknown): SavedSession | null {
   if (typeof payload !== 'object' || payload === null) return null;
   const raw = payload as Record<string, unknown>;
 
@@ -328,7 +346,6 @@ function parseSaved(payload: unknown, now: number): SavedSession | null {
   // Sessions carried one, and either way there is no telling how old it is.
   const endsAt = raw.endsAt;
   if (typeof endsAt !== 'number' || !Number.isFinite(endsAt)) return null;
-  if (now - endsAt > RESUME_WINDOW_MS) return null;
 
   const remainingSeconds =
     typeof raw.remainingSeconds === 'number' && Number.isFinite(raw.remainingSeconds)

--- a/src/pages/tools/flowstate-timer.astro
+++ b/src/pages/tools/flowstate-timer.astro
@@ -263,7 +263,7 @@ const description = 'A focus and break timer to help you lock in. 90 minutes on,
       case 'save': {
         // toSaved decides what may be restored; nothing to save means nothing
         // should stay on disk either.
-        const payload = toSaved(session);
+        const payload = toSaved(session, Date.now());
         if (payload) localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
         else apply('clearSaved');
         break;

--- a/tests/lib/timer.test.ts
+++ b/tests/lib/timer.test.ts
@@ -352,6 +352,20 @@ describe('Session', () => {
       expect(effects).toEqual(['clearSaved']);
     });
 
+    it('ages a paused payload from when it was left, not from when it would have ended', () => {
+      // Paused with 80 minutes on it, so its Deadline is still ahead at T0+80 —
+      // but it has sat untouched for 70 minutes, and that is what makes it stale.
+      const paused = run(running(90), { type: 'pause', now: T0 + 10 * MINUTE });
+      const payload = toSaved(paused, T0 + 10 * MINUTE);
+
+      const fresh = reduce(initialSession(), { type: 'restore', payload, now: T0 + 69 * MINUTE });
+      expect(fresh.session.status).toBe('paused');
+
+      const stale = reduce(initialSession(), { type: 'restore', payload, now: T0 + 71 * MINUTE });
+      expect(stale.session).toEqual(initialSession());
+      expect(stale.effects).toEqual(['clearSaved']);
+    });
+
     it('drops a paused payload left alone for longer than the resume window', () => {
       const paused = run(running(90), { type: 'pause', now: T0 + 10 * MINUTE });
       const { session, effects } = reduce(initialSession(), {

--- a/tests/lib/timer.test.ts
+++ b/tests/lib/timer.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_FOCUS_MINUTES,
   FOCUS_PHRASES,
   MAX_MINUTES,
+  RESUME_WINDOW_MS,
   formatTime,
   initialSession,
   modeLabel,
@@ -279,7 +280,7 @@ describe('Session', () => {
 
   describe('restore', () => {
     it('restores a running payload as paused, with the time actually left', () => {
-      const saved = toSaved(running(90));
+      const saved = toSaved(running(90), T0);
       const { session, effects } = reduce(initialSession(), {
         type: 'restore',
         payload: saved,
@@ -296,8 +297,8 @@ describe('Session', () => {
       const paused = run(running(90), { type: 'pause', now: T0 + 10 * MINUTE });
       const { session } = reduce(initialSession(), {
         type: 'restore',
-        payload: toSaved(paused),
-        now: T0 + 400 * MINUTE,
+        payload: toSaved(paused, T0 + 10 * MINUTE),
+        now: T0 + 30 * MINUTE,
       });
       expect(session.status).toBe('paused');
       expect(session.remainingSeconds).toBe(80 * 60);
@@ -314,20 +315,52 @@ describe('Session', () => {
       );
       const { session } = reduce(initialSession(), {
         type: 'restore',
-        payload: toSaved(withChoices),
+        payload: toSaved(withChoices, T0 + 46 * MINUTE),
         now: T0 + 46 * MINUTE,
       });
       expect(session.lastFocusSeconds).toBe(45 * 60);
       expect(session.breakSeconds).toBe(5 * 60);
     });
 
-    it('clamps a payload whose Deadline has already passed to zero', () => {
+    it('clamps a payload whose Deadline has just passed to zero', () => {
       const { session } = reduce(initialSession(), {
         type: 'restore',
-        payload: toSaved(running(90)),
+        payload: toSaved(running(90), T0),
+        now: T0 + 95 * MINUTE,
+      });
+      expect(session.status).toBe('paused');
+      expect(session.remainingSeconds).toBe(0);
+    });
+
+    it('offers a payload whose Deadline passed exactly the resume window ago', () => {
+      const { session, effects } = reduce(initialSession(), {
+        type: 'restore',
+        payload: toSaved(running(90), T0),
+        now: T0 + 90 * MINUTE + RESUME_WINDOW_MS,
+      });
+      expect(session.status).toBe('paused');
+      expect(effects).toEqual([]);
+    });
+
+    it('drops a payload whose Deadline passed more than the resume window ago', () => {
+      const { session, effects } = reduce(initialSession(), {
+        type: 'restore',
+        payload: toSaved(running(90), T0),
+        now: T0 + 90 * MINUTE + RESUME_WINDOW_MS + 1,
+      });
+      expect(session).toEqual(initialSession());
+      expect(effects).toEqual(['clearSaved']);
+    });
+
+    it('drops a paused payload left alone for longer than the resume window', () => {
+      const paused = run(running(90), { type: 'pause', now: T0 + 10 * MINUTE });
+      const { session, effects } = reduce(initialSession(), {
+        type: 'restore',
+        payload: toSaved(paused, T0 + 10 * MINUTE),
         now: T0 + 400 * MINUTE,
       });
-      expect(session.remainingSeconds).toBe(0);
+      expect(session).toEqual(initialSession());
+      expect(effects).toEqual(['clearSaved']);
     });
 
     it.each([
@@ -336,8 +369,11 @@ describe('Session', () => {
       ['an empty object', {}],
       ['an unknown mode', { status: 'running', mode: 'sleep', totalSeconds: 60, endsAt: T0 }],
       ['a running payload with no Deadline', { status: 'running', mode: 'focus', totalSeconds: 60, endsAt: null }],
-      ['a non-numeric duration', { status: 'paused', mode: 'focus', totalSeconds: 'lots', remainingSeconds: 10 }],
-      ['a zero duration', { status: 'paused', mode: 'focus', totalSeconds: 0, remainingSeconds: 0 }],
+      ['a paused payload with no Deadline', { status: 'paused', mode: 'focus', totalSeconds: 60, remainingSeconds: 10 }],
+      ['a payload from the previous version', { remainingSeconds: 300, totalSeconds: 5400, mode: 'focus', savedAt: T0 }],
+      ['a non-numeric duration', { status: 'paused', mode: 'focus', totalSeconds: 'lots', remainingSeconds: 10, endsAt: T0 }],
+      ['a zero duration', { status: 'paused', mode: 'focus', totalSeconds: 0, remainingSeconds: 0, endsAt: T0 }],
+      ['a paused payload with no remaining time recorded', { status: 'paused', mode: 'focus', totalSeconds: 60, endsAt: T0 }],
     ])('falls back to a fresh Session and clears the save for %s', (_label, payload) => {
       const { session, effects } = reduce(running(90), { type: 'restore', payload, now: T0 });
       expect(session).toEqual(initialSession());
@@ -347,47 +383,51 @@ describe('Session', () => {
     it('says whether there is anything to offer the viewer', () => {
       const restored = (payload: unknown) =>
         reduce(initialSession(), { type: 'restore', payload, now: T0 }).session;
-      expect(canResume(restored(toSaved(running(90))))).toBe(true);
+      expect(canResume(restored(toSaved(running(90), T0)))).toBe(true);
       expect(canResume(restored('junk'))).toBe(false);
       expect(canResume(initialSession())).toBe(false);
     });
 
-    it('accepts a legacy payload that predates the status field', () => {
-      const { session, effects } = reduce(initialSession(), {
+    it('states the time genuinely left, not the time the Session was saved with', () => {
+      const paused = run(running(90), { type: 'pause', now: T0 + 70 * MINUTE });
+      const { session } = reduce(initialSession(), {
         type: 'restore',
-        payload: { remainingSeconds: 300, totalSeconds: 5400, mode: 'focus', savedAt: T0 },
-        now: T0,
+        payload: toSaved(run(paused, { type: 'resume', now: T0 + 70 * MINUTE }), T0 + 70 * MINUTE),
+        now: T0 + 86 * MINUTE,
       });
-      expect(session.status).toBe('paused');
-      expect(session.remainingSeconds).toBe(300);
-      expect(session.totalSeconds).toBe(5400);
-      expect(effects).toEqual([]);
+      expect(session.remainingSeconds).toBe(4 * 60);
+      expect(resumeMessage(session)).toBe('You had 4 minutes left on your focus timer. Resume?');
     });
   });
 
   describe('saved payload', () => {
     it('saves a running Session with its Deadline', () => {
-      const saved = toSaved(running(90));
+      const saved = toSaved(running(90), T0);
       expect(saved).toMatchObject({ status: 'running', mode: 'focus', endsAt: T0 + 90 * MINUTE });
     });
 
-    it('saves a paused Session with its remaining time', () => {
-      const saved = toSaved(run(running(90), { type: 'pause', now: T0 + 10 * MINUTE }));
-      expect(saved).toMatchObject({ status: 'paused', remainingSeconds: 80 * 60, endsAt: null });
+    it('saves a paused Session with its remaining time, and the Deadline it would have', () => {
+      const savedAt = T0 + 10 * MINUTE;
+      const saved = toSaved(run(running(90), { type: 'pause', now: savedAt }), savedAt);
+      expect(saved).toMatchObject({
+        status: 'paused',
+        remainingSeconds: 80 * 60,
+        endsAt: savedAt + 80 * MINUTE,
+      });
     });
 
     it('saves nothing for an idle, ringing or transition Session', () => {
       const ringing = run(running(1), { type: 'tick', now: T0 + MINUTE });
-      expect(toSaved(initialSession())).toBeNull();
-      expect(toSaved(ringing)).toBeNull();
-      expect(toSaved(run(ringing, { type: 'dismiss', draw: 0 }))).toBeNull();
+      expect(toSaved(initialSession(), T0)).toBeNull();
+      expect(toSaved(ringing, T0)).toBeNull();
+      expect(toSaved(run(ringing, { type: 'dismiss', draw: 0 }), T0)).toBeNull();
     });
 
     it('round-trips through restore', () => {
       const paused = run(running(90), { type: 'pause', now: T0 + 10 * MINUTE });
       const { session } = reduce(initialSession(), {
         type: 'restore',
-        payload: JSON.parse(JSON.stringify(toSaved(paused))),
+        payload: JSON.parse(JSON.stringify(toSaved(paused, T0 + 10 * MINUTE))),
         now: T0 + 20 * MINUTE,
       });
       expect(session).toEqual(paused);
@@ -410,7 +450,7 @@ describe('Session', () => {
       ['dismiss', ringing, { type: 'dismiss', draw: 0 }, ['stopAlarm', 'stopPulse']],
       ['chooseBreak', transition, { type: 'chooseBreak', minutes: 15 }, []],
       ['repeatFocus', transition, { type: 'repeatFocus', now: T0 + 2 * MINUTE }, ['showStarfield', 'playEntrance', 'save']],
-      ['restore', initialSession(), { type: 'restore', payload: toSaved(paused), now: T0 + 2 * MINUTE }, []],
+      ['restore', initialSession(), { type: 'restore', payload: toSaved(paused, T0 + MINUTE), now: T0 + 2 * MINUTE }, []],
       ['restore of junk', initialSession(), { type: 'restore', payload: 'junk', now: T0 }, ['clearSaved']],
     ])('%s', (_label, session, event, expected) => {
       expect(reduce(session, event).effects).toEqual(expected);
@@ -491,14 +531,14 @@ describe('Session', () => {
       const restored = (payload: unknown, now: number) =>
         reduce(initialSession(), { type: 'restore', payload, now }).session;
 
-      const focus = restored(toSaved(running(90)), T0 + 30 * MINUTE);
+      const focus = restored(toSaved(running(90), T0), T0 + 30 * MINUTE);
       expect(resumeMessage(focus)).toBe('You had 60 minutes left on your focus timer. Resume?');
 
-      const almostDone = restored(toSaved(running(90)), T0 + 89 * MINUTE);
+      const almostDone = restored(toSaved(running(90), T0), T0 + 89 * MINUTE);
       expect(resumeMessage(almostDone)).toBe('You had 1 minute left on your focus timer. Resume?');
 
       const onBreak = restored(
-        toSaved(run(initialSession(), { type: 'start', mode: 'break', minutes: 30, now: T0 })),
+        toSaved(run(initialSession(), { type: 'start', mode: 'break', minutes: 30, now: T0 }), T0),
         T0 + 10 * MINUTE,
       );
       expect(resumeMessage(onBreak)).toBe('You had 20 minutes left on your break timer. Resume?');


### PR DESCRIPTION
Closes #25

Reopening the Flowstate timer long after walking away offered to resume a Session that was over, and stated the time left when the page was closed rather than the time left now.

## What changed

- **Resume Window** (`RESUME_WINDOW_MS`, one hour) — how long after a Session was last live it is still worth offering back. Past it, the payload is dropped and storage cleared, and the viewer lands on the preset screen.
- Every saved payload now carries a **Deadline**, a paused one included: there it is the instant the Session would end had it kept running from the save. `toSaved` takes `now`; `SavedSession.endsAt` is no longer nullable.
- Last live means the Deadline while running, and the save instant while paused — a paused Session counts down no further, so what makes it stale is how long ago it was left. Both are read off the Deadline the payload already carries.
- Restore deducts elapsed time for a running payload, so the prompt states what is genuinely left. Leave with 20 minutes, come back 16 minutes later, and it says 4.
- No version field and no migration: payloads written before Sessions carried a Deadline carry none, so they are unrecognised and drop like any other junk. A Session in progress when this deploys is lost once.
- `parseSaved` answers only whether a payload has the right shape; expiry lives in `withinResumeWindow` beside it.

## Two calls worth reviewing

1. **Paused expiry** — the acceptance criteria define the rule in terms of the Deadline, which is only meaningful for a running Session. Ageing a paused save from the instant it was left is my reading of *"a saved Session older than 60 minutes is dropped"*; measuring from its notional Deadline instead would give a 90-minute paused Session a ~2.5 hour grace period.
2. **A Session whose Deadline passed inside the window** restores at zero and is still offered — "You had 0 minutes left on your focus timer. Resume?", and resuming starts a timer that rings at once. That follows the spec literally (drop only past 60 minutes), but dropping any expired Session may be the better behaviour. Happy to change it.

## Verification

`bun run test` (550 pass), `bunx astro check` (0 errors), `bun run build` all pass. Tests cover live, just-expired, exactly at the window boundary, long-expired, paused-left-too-long, previous-version and malformed payloads, against the module interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)