### PR TITLE
Carry the chosen focus duration across a break

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,13 @@ which is why the two vocabularies are not the same list.
 *derived* from it, never counted down, so a hidden tab, a sleeping machine or a page reload
 cannot make the Session drift. Replaced a per-frame decrement plus a backup `setTimeout`.
 
+**Remembered Focus** — the focus duration last chosen (`lastFocusSeconds`), and what a focus
+Session starts at whenever the viewer has not just picked one. Written the moment a focus
+Session *starts*, not when it completes, so a duration abandoned mid-Session is still the last
+answer; a break start leaves it alone. Both **Repeat Focus** and the **Start Focus** that
+follows a break read it, which is what keeps the two paths from disagreeing — they were two
+hardcoded defaults before. A first Session, having chosen nothing, gets `DEFAULT_FOCUS_MINUTES`.
+
 **Effect** — something the page must do that a pure module cannot: `startAlarm`, `stopAlarm`,
 `pulseRing`, `stopPulse`, `showStarfield`, `playEntrance`, `clearSaved`, `save`. The reducer
 decides which Effects a transition produces; the page only knows how to perform each one, and

--- a/src/lib/timer/session.ts
+++ b/src/lib/timer/session.ts
@@ -31,7 +31,12 @@ export interface Session {
   endsAt: number | null;
   /** Time left. Derived from the Deadline while running; held while paused. */
   remainingSeconds: number;
-  /** How long the last completed focus Session ran — what "Repeat Focus" uses. */
+  /**
+   * The focus duration last chosen — what a focus Session starts at when the
+   * viewer has not just picked one. Both "Repeat Focus" and the "Start Focus"
+   * that follows a break read it, so the two agree. Only a focus Session
+   * starting writes it; a break leaves it alone.
+   */
   lastFocusSeconds: number;
   /** The break duration currently chosen on the transition screen. */
   breakSeconds: number;
@@ -162,6 +167,9 @@ function begin(session: Session, mode: Mode, totalSeconds: number, now: number):
       totalSeconds,
       endsAt: now + totalSeconds * 1000,
       remainingSeconds: totalSeconds,
+      // A focus duration is remembered the moment it is chosen, not when the
+      // Session it started completes — an abandoned 45 is still the last answer.
+      lastFocusSeconds: mode === 'focus' ? totalSeconds : session.lastFocusSeconds,
       phrase: null,
     },
     effects: ['showStarfield', 'playEntrance', 'save'],
@@ -190,8 +198,6 @@ export function reduce(session: Session, event: Event): Outcome {
           status: 'ringing',
           endsAt: null,
           remainingSeconds: 0,
-          lastFocusSeconds:
-            session.mode === 'focus' ? session.totalSeconds : session.lastFocusSeconds,
         },
         effects: ['clearSaved', 'startAlarm', 'pulseRing'],
       };
@@ -420,7 +426,7 @@ export function defaultMinutes(mode: Mode): number {
 export function nextStart(session: Session): { mode: Mode; minutes: number } {
   return session.mode === 'focus'
     ? { mode: 'break', minutes: Math.round(session.breakSeconds / 60) }
-    : { mode: 'focus', minutes: DEFAULT_FOCUS_MINUTES };
+    : { mode: 'focus', minutes: Math.round(session.lastFocusSeconds / 60) };
 }
 
 export interface TransitionView {

--- a/tests/lib/timer.test.ts
+++ b/tests/lib/timer.test.ts
@@ -98,6 +98,62 @@ describe('Session', () => {
       });
       expect(effects).toEqual(['showStarfield', 'playEntrance', 'save']);
     });
+
+    it('remembers a chosen focus duration as soon as the Session starts', () => {
+      expect(running(45).lastFocusSeconds).toBe(45 * 60);
+    });
+
+    it('remembers the clamped duration, not the one asked for', () => {
+      expect(running(9999).lastFocusSeconds).toBe(MAX_MINUTES * 60);
+    });
+
+    it('leaves the remembered focus duration alone when a break starts', () => {
+      const afterBreakStart = run(running(45), {
+        type: 'start',
+        mode: 'break',
+        minutes: 5,
+        now: T0,
+      });
+      expect(afterBreakStart.lastFocusSeconds).toBe(45 * 60);
+    });
+  });
+
+  describe('carrying a chosen focus duration across a break', () => {
+    /** A custom focus, run to completion, then a break run to completion. */
+    function afterCustomFocusAndBreak(focusMinutes: number): Session {
+      return run(
+        running(focusMinutes),
+        { type: 'tick', now: T0 + focusMinutes * MINUTE },
+        { type: 'dismiss', draw: 0 },
+        { type: 'start', mode: 'break', minutes: 5, now: T0 },
+        { type: 'tick', now: T0 + 5 * MINUTE },
+        { type: 'dismiss', draw: 0 },
+      );
+    }
+
+    it('starts the post-break focus at the duration last chosen', () => {
+      const transition = afterCustomFocusAndBreak(45);
+      const next = nextStart(transition);
+      const focus = run(transition, { type: 'start', ...next, now: T0 });
+      expect(focus.mode).toBe('focus');
+      expect(focus.totalSeconds).toBe(45 * 60);
+    });
+
+    it('starts Repeat Focus at that same duration', () => {
+      const transition = run(
+        running(45),
+        { type: 'tick', now: T0 + 45 * MINUTE },
+        { type: 'dismiss', draw: 0 },
+      );
+      expect(run(transition, { type: 'repeatFocus', now: T0 }).totalSeconds).toBe(45 * 60);
+    });
+
+    it('takes a newly chosen duration over the remembered one', () => {
+      const transition = afterCustomFocusAndBreak(45);
+      const focus = run(transition, { type: 'start', mode: 'focus', minutes: 20, now: T0 });
+      expect(focus.totalSeconds).toBe(20 * 60);
+      expect(focus.lastFocusSeconds).toBe(20 * 60);
+    });
   });
 
   describe('tick', () => {
@@ -509,6 +565,16 @@ describe('Session', () => {
 
       const afterBreak = run(
         afterFocus,
+        { type: 'start', mode: 'break', minutes: 5, now: T0 },
+        { type: 'tick', now: T0 + 5 * MINUTE },
+        { type: 'dismiss', draw: 0 },
+      );
+      expect(nextStart(afterBreak)).toEqual({ mode: 'focus', minutes: 45 });
+    });
+
+    it('offers the default focus duration after a break in a Session that chose none', () => {
+      const afterBreak = run(
+        initialSession(),
         { type: 'start', mode: 'break', minutes: 5, now: T0 },
         { type: 'tick', now: T0 + 5 * MINUTE },
         { type: 'dismiss', draw: 0 },


### PR DESCRIPTION
Closes #26

A focus duration you chose survived Repeat Focus but not a break. Set a custom 45, finish it, take a break, hit Start Focus — you got 90, because the post-break path hardcoded the default. The two paths disagreed because each held its own rule.

## What changed

`src/lib/timer/session.ts`, 14 lines:

- `begin()` writes `lastFocusSeconds` when the mode is focus, so a duration is remembered the moment it is chosen rather than when the Session completes.
- The completion-time write in `tick` is gone — `begin` owning it makes that branch redundant. Two rules became one.
- `nextStart()` reads the remembered value instead of `DEFAULT_FOCUS_MINUTES`.

The page needed no change: `breakBtn` already routes through `nextStart`.

`CONTEXT.md` gains a **Remembered Focus** term — the duration is now a rule (written at start, read by two buttons), and CONTEXT.md documents Deadline and Resume Window at that granularity.

## Judgement call worth a reviewer's eye

The write point moved from completion to start. The issue's "remember the last focus duration" is ambiguous about when, but "choosing a preset or entering a custom duration updates the remembered duration" points at choice-time, so that is the reading taken. It does change observable behaviour for abandoned and reset Sessions — no acceptance criterion names that case and no test pins it.

## Noted, not fixed

`selectMode` writes `selectedMinutes` without syncing the preset highlight or custom box. That drift predates this change and this change narrows it: typing a custom 45 then taking a break used to leave `selectedMinutes` at 90 while the box still read "45"; now both say 45. The residual — toggling modes resets `selectedMinutes` to the default while a stale custom value stays visible — is outside this issue's scope.

## Testing

- New tests at the module interface: the start-time write, the clamped value, the break-does-not-overwrite guard, the first-Session default, and a `carrying a chosen focus duration across a break` block running the full focus → ring → dismiss → break → ring → dismiss → `nextStart` chain.
- `bun run test` — 557 pass across 24 files.
- `bun run build` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)